### PR TITLE
PADV-269 Adding the interaction with the sidebar MFE.

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,8 @@ const { createConfig } = require('@edx/frontend-build');
 
 module.exports = createConfig('jest', {
   // setupFilesAfterEnv is used after the jest environment has been loaded.  In general this is what you want.  
-  // If you want to add config BEFORE jest loads, use setupFiles instead.  
+  // If you want to add config BEFORE jest loads, use setupFiles instead.
+  moduleDirectories: ['node_modules', 'src'],
   setupFilesAfterEnv: [
     '<rootDir>/src/setupTest.js',
   ],

--- a/src/features/outline/CourseOutline.jsx
+++ b/src/features/outline/CourseOutline.jsx
@@ -7,6 +7,7 @@ import { fetchCourseOutline } from 'features/outline/data';
 import messages from 'features/outline/messages';
 import Section from 'features/outline/Section';
 import { FAILED, LOADING } from 'features/outline/data/slice';
+import { handleOutlineEvent } from 'features/outline/eventsHandler';
 
 function CourseOutline() {
   const { courseId: courseIdFromUrl } = useParams();
@@ -25,6 +26,12 @@ function CourseOutline() {
     sections,
   } = useSelector(state => state.outline.outlineData);
   const [expandAll, setExpandAll] = useState(false);
+
+  // If an event occurs in frontend-app-learning setExpandAll will be set as true.
+  useEffect(() => {
+    handleOutlineEvent(setExpandAll);
+  }, [setExpandAll]);
+
   if (courseStatus === LOADING) {
     return (
       <h3>{messages.loading.defaultMessage}</h3>

--- a/src/features/outline/Section.jsx
+++ b/src/features/outline/Section.jsx
@@ -5,6 +5,7 @@ import { Collapsible, IconButton } from '@edx/paragon';
 import { faCheckCircle as fasCheckCircle, faMinus, faPlus } from '@fortawesome/free-solid-svg-icons';
 import { faCheckCircle as farCheckCircle } from '@fortawesome/free-regular-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { handleOutlineEvent } from 'features/outline/eventsHandler';
 
 import SequenceLink from 'features/outline/SequenceLink';
 import messages from 'features/outline/messages';
@@ -32,6 +33,11 @@ function Section({
   useEffect(() => {
     setOpen(defaultOpen);
   }, [defaultOpen]);
+
+  // If an event occurs in frontend-app-learning setOpen will be set as true.
+  useEffect(() => {
+    handleOutlineEvent(setOpen);
+  }, [setOpen]);
 
   const sectionTitle = (
     <div className="row w-100 m-0 align-items-center">

--- a/src/features/outline/SequenceLink.jsx
+++ b/src/features/outline/SequenceLink.jsx
@@ -3,33 +3,19 @@ import PropTypes from 'prop-types';
 import { faCheckCircle as fasCheckCircle } from '@fortawesome/free-solid-svg-icons';
 import { faCheckCircle as farCheckCircle } from '@fortawesome/free-regular-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { getConfig } from '@edx/frontend-platform';
-
+import { Button } from '@edx/paragon';
 import messages from 'features/outline/messages';
+import { postEventOutlineToParent } from 'features/outline/eventsHandler';
 
 function SequenceLink({
   id,
-  courseId,
   first,
   sequence,
 }) {
   const {
     complete,
-    showLink,
     title,
   } = sequence;
-  const coursewareUrl = (
-    <a
-      href={`${getConfig().LEARNING_BASE_URL}course/${courseId}/${id}`}
-      target="_blank"
-      rel="noreferrer"
-      className="p-0 ml-3 text-break"
-      aria-label={`${title}, ${complete ? messages.completedAssignment.defaultMessage : messages.incompleteAssignment.defaultMessage}`}
-    >
-      {title}
-    </a>
-  );
-  const displayTitle = showLink ? coursewareUrl : title;
 
   return (
     <li className={`w-100 m-0 pl-3 d-flex align-items-center ${!first && 'mt-2 pt-2 border-top border-light'}`}>
@@ -50,14 +36,18 @@ function SequenceLink({
           title={messages.incompleteAssignment.defaultMessage}
         />
       )}
-      {displayTitle}
+      <Button.Deprecated
+        className="btn-link"
+        onClick={() => { postEventOutlineToParent('outline_sidebar_navigation_started', id); }}
+      >
+        {title}
+      </Button.Deprecated>
     </li>
   );
 }
 
 SequenceLink.propTypes = {
   id: PropTypes.string.isRequired,
-  courseId: PropTypes.string.isRequired,
   first: PropTypes.bool.isRequired,
   sequence: PropTypes.shape().isRequired,
 };

--- a/src/features/outline/eventsHandler.js
+++ b/src/features/outline/eventsHandler.js
@@ -1,0 +1,51 @@
+/* eslint-disable object-shorthand */
+
+import { getConfig } from '@edx/frontend-platform';
+
+/**
+ * Helper function to make a postEvent call.
+ * @param {string} message with the name of the event
+ * @param {string} id xBlock with id of the subsection
+ *  useCase: In another route, the event is received in
+ *  the MFE with the message and within its data it contains
+ *  the subsection id.
+ */
+export function postEventOutlineToParent(message, id) {
+  const messageTargets = [
+    getConfig().LEARNING_BASE_URL,
+  ];
+
+  messageTargets.forEach(target => {
+    window.parent.postMessage(
+      {
+        message: message,
+        subsection_id: id,
+      },
+      target,
+    );
+  });
+}
+
+/**
+ * Helper function to handle when an event occurs for Outline Navigation Sidebar.
+ * @param {string} message with the name of the event
+ * @param {state} set state as true.
+ *  useCase: An event is received from a different route to the MFE through a
+ *  message and the desired functionality is executed.
+ *
+ *  example: const [expandAll, setExpandAll] = useState(false);
+ *  handleOutlineEvent(setExpandAll);
+ */
+export function handleOutlineEvent(callback) {
+  const handleMessage = (event) => {
+    if (event.data.message === 'outline_event') {
+      callback(true);
+    }
+  };
+
+  window.addEventListener('message', handleMessage);
+  // Cleanup eventListener.
+  return () => {
+    window.removeEventListener('message', handleMessage);
+  };
+}

--- a/src/features/outline/eventsHandler.test.js
+++ b/src/features/outline/eventsHandler.test.js
@@ -1,0 +1,41 @@
+import { postEventOutlineToParent, handleOutlineEvent } from 'features/outline/eventsHandler';
+import { getConfig } from '@edx/frontend-platform';
+
+describe('postEventOutlineToParent', () => {
+  beforeEach(() => {
+    window.parent.postMessage = window.postMessage;
+  });
+
+  afterEach(() => {
+    window.parent.postMessage = window.postMessage;
+  });
+
+  it('should call postMessage with the correct arguments', () => {
+    jest.spyOn(window.parent, 'postMessage');
+
+    postEventOutlineToParent('event_name', 'subsection_id');
+
+    expect(window.parent.postMessage).toHaveBeenCalledWith({
+      message: 'event_name',
+      subsection_id: 'subsection_id',
+    }, getConfig().LEARNING_BASE_URL);
+  });
+});
+
+describe('handleOutlineEvent', () => {
+  let callback;
+  beforeEach(() => {
+    callback = jest.fn();
+    handleOutlineEvent(callback);
+  });
+
+  it('should call the callback with true when it receives an outline_event message', () => {
+    window.dispatchEvent(new MessageEvent('message', { data: { message: 'outline_event' } }));
+    expect(callback).toHaveBeenCalledWith(true);
+  });
+
+  it('should not call the callback when it receives an non-outline_event message', () => {
+    window.dispatchEvent(new MessageEvent('message', { data: { message: 'other_event' } }));
+    expect(callback).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-269

## Description

In this PR the interaction between frontend-app-navigation-sidebar MFE and frontend-app-learning is added.  Where, the signals of each one are captured, so that the sidebar MFE can be executed maintaining its state, following the requirements given in: [Requirements Document](https://pearsoneducationinc-my.sharepoint.com/:w:/r/personal/scott_dunn_pearson_com/_layouts/15/doc2.aspx?sourcedoc=%7BC7CD8FBB-2DCE-4A3E-BD2F-39006EB2B222%7D&file=Sidebar%20Navigation.docx&action=default&mobileredirect=true&cid=592c950a-13c2-4e0b-88e2-666e948cd4fa).

The interaction can be seen at:

![PADV-269](https://user-images.githubusercontent.com/30726391/211398114-e90dba92-5dd4-4a93-940d-5bf671dd2545.gif)

## Type of Change

- [x] Add event Listener in `CourseOutline` to capture the signal from frontend-app-learning MFE and set setExpandAll as true.
- [x] Add event Listener in `Section` to capture the signal from frontend-app-learning MFE and set setOpen as true.
- [x] Add `postEventOutlineToParent` function in `utils` module to communicate the outline sidebar navigation MFE and frontend-app-learning.
- [x] Add Button from paragon in SequenceLink to use `postEventOutlineToParent`.
- [x] Add respective tests for `CourseOutine` and `Section` modules.

## PR's Related:

- [PR for PADV-269 frontend-app-learning MFE](https://github.com/Pearson-Advance/frontend-app-learning/pull/3)

## Testing

- Follow the test steps in: [PADV-269 frontend-app-learning](https://github.com/Pearson-Advance/frontend-app-learning/pull/3)

## Reviewers

- [x] @Squirrel18 
- [x] @alexjmpb  