### PR TITLE
PADV 888 - Sidebar styling fixes

### DIFF
--- a/src/features/outline/CourseOutline.jsx
+++ b/src/features/outline/CourseOutline.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useParams } from 'react-router';
-import { Button } from '@edx/paragon';
+import { Button, Spinner } from '@edx/paragon';
 
 import { fetchCourseOutline } from 'features/outline/data';
 import messages from 'features/outline/messages';
@@ -34,19 +34,21 @@ function CourseOutline() {
 
   if (courseStatus === LOADING) {
     return (
-      <h3>{messages.loading.defaultMessage}</h3>
+      <div className="w-100 d-flex justify-content-center h-100 mt-3" data-testid="spinner-wrapper">
+        <Spinner animation="border" variant="primary" screenReaderText={messages.loading.defaultMessage} />
+      </div>
     );
   }
 
   if (courseStatus === FAILED) {
     return (
-      <h3>{messages.failed.defaultMessage}</h3>
+      <p className="text-danger m-3 text-center">{messages.failed.defaultMessage}</p>
     );
   }
 
   return (
-    <aside className="sidebar">
-      <nav className="p-3" aria-label="Sidebar Navigation">
+    <aside className="sidebar-outline-wrapper">
+      <nav className="sidebar-outline p-3" aria-label="Sidebar Navigation">
         <Button
           id="expandButton"
           variant="outline-primary w-100 mb-3"
@@ -54,7 +56,7 @@ function CourseOutline() {
         >
           {expandAll ? messages.collapseAll.defaultMessage : messages.expandAll.defaultMessage}
         </Button>
-        <ol id="sidebar-outline" className="list-unstyled">
+        <ol className="sidebar-section-wrapper list-unstyled">
           {course.sectionIds.map((sectionId) => (
             <Section
               key={sectionId}

--- a/src/features/outline/CourseOutline.test.jsx
+++ b/src/features/outline/CourseOutline.test.jsx
@@ -57,22 +57,22 @@ describe('CourseOutline', () => {
     });
 
     test('content is rendered correctly when courseStatus is loaded', async () => {
-      const asideSidebar = document.querySelector('aside.sidebar');
+      const asideSidebar = document.querySelector('.sidebar-section-wrapper');
 
       expect(document.body).toContainElement(asideSidebar);
     });
 
     test('section map the correct number of sections', async () => {
-      const sectionList = document.querySelectorAll('li.section-wrapper');
+      const sectionList = document.querySelectorAll('li.sidebar-section');
 
       expect(sectionList).toHaveLength(1);
     });
   });
 
   test('when courseStatus is loading', () => {
-    render(component);
+    const { getByTestId } = render(component);
 
-    expect(document.body).toHaveTextContent(messages.loading.defaultMessage);
+    expect(document.body).toContainElement(getByTestId('spinner-wrapper'));
   });
 
   test('when courseStatus is failed', async () => {

--- a/src/features/outline/Section.jsx
+++ b/src/features/outline/Section.jsx
@@ -68,7 +68,7 @@ function Section({
   );
 
   return (
-    <li className="section-wrapper">
+    <li className="sidebar-section">
       <Collapsible
         className="mb-2"
         styling="card-lg"
@@ -92,7 +92,7 @@ function Section({
           />
         )}
       >
-        <ol className="list-unstyled subsection-list">
+        <ol className="list-unstyled sidebar-sequence-wrapper">
           {sequenceIds.map((sequenceId, index) => (
             <SequenceLink
               key={sequenceId}

--- a/src/features/outline/Section.test.jsx
+++ b/src/features/outline/Section.test.jsx
@@ -94,7 +94,7 @@ describe('Section', () => {
       defaultOpen: true,
     });
 
-    const subsectionList = document.querySelector('.section-wrapper div:first-child');
+    const subsectionList = document.querySelector('.sidebar-section div:first-child');
 
     expect(subsectionList).toHaveAttribute('open');
   });
@@ -106,7 +106,7 @@ describe('Section', () => {
       defaultOpen: false,
     });
 
-    const subsectionList = document.querySelector('.section-wrapper div:first-child');
+    const subsectionList = document.querySelector('.sidebar-section div:first-child');
 
     expect(subsectionList).not.toHaveAttribute('open');
   });

--- a/src/features/outline/SequenceLink.jsx
+++ b/src/features/outline/SequenceLink.jsx
@@ -18,7 +18,12 @@ function SequenceLink({
   } = sequence;
 
   return (
-    <li className={`w-100 m-0 pl-3 d-flex align-items-center ${!first && 'mt-2 pt-2 border-top border-light'}`}>
+    <li
+      className={
+        `sidebar-sequence w-100 m-0 pl-3 d-flex align-items-center
+        ${!first && ' mt-2 pt-2 border-top border-light'}`
+      }
+    >
       {complete ? (
         <FontAwesomeIcon
           icon={fasCheckCircle}

--- a/src/features/outline/SequenceLink.test.jsx
+++ b/src/features/outline/SequenceLink.test.jsx
@@ -74,9 +74,9 @@ describe('Section', () => {
       sequence,
     });
 
-    const sequenceWrapper = document.querySelector('li.w-100.m-0.pl-3.d-flex.align-items-center');
+    const sidebarSequence = document.querySelector('.sidebar-sequence');
 
-    expect(sequenceWrapper).not.toHaveClass('mt-2 pt-2 border-top border-light');
+    expect(sidebarSequence).not.toHaveClass('mt-2 pt-2 border-top border-light');
   });
 
   test('sequence is styled correctly when is not first', () => {
@@ -90,8 +90,8 @@ describe('Section', () => {
       first: false,
     });
 
-    const sequenceWrapper = document.querySelector('li.w-100.m-0.pl-3.d-flex.align-items-center');
+    const sidebarSequence = document.querySelector('.sidebar-sequence');
 
-    expect(sequenceWrapper).toHaveClass('mt-2 pt-2 border-top border-light');
+    expect(sidebarSequence).toHaveClass('mt-2 pt-2 border-top border-light');
   });
 });

--- a/src/index.scss
+++ b/src/index.scss
@@ -9,12 +9,21 @@
   flex-direction: column;
   min-height: 100vh;
 
-  main {
-    flex-grow: 1;
-  }
-
-  aside,
-  nav {
+  aside.sidebar-outline-wrapper nav.sidebar-outline {
     box-sizing: border-box;
+
+    ol.sidebar-section-wrapper {
+      li.sidebar-section {
+        .collapsible-card-lg .collapsible-trigger > div {
+          flex-flow: row;
+        }
+
+        ol.sidebar-sequence-wrapper {
+          li.sidebar-sequence button.btn-link {
+            text-align: left;
+          }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Description:

This PR aims to fix various styles in the sidebar navigation that may affect the user experience.

## Changes Made

- [x] Align text to left inside sequence text.
- [x] Improve loading screen.
- [x] Improve error screen.

## Screenshots

### Text align

#### Before

![Screenshot from 2023-12-04 12-27-03](https://github.com/Pearson-Advance/frontend-app-sidebar-navigation/assets/62396424/b410d4f0-766d-4690-9715-14377762af22)

#### After

![Screenshot from 2023-12-04 12-26-22](https://github.com/Pearson-Advance/frontend-app-sidebar-navigation/assets/62396424/cf09df56-685d-4173-a278-f9537e3f6724)

### Loading screen

#### Before
![Screenshot from 2023-12-04 12-27-10](https://github.com/Pearson-Advance/frontend-app-sidebar-navigation/assets/62396424/69e094d2-6e71-4200-80f2-a1f5e9df6c02)

#### After 

![Screenshot from 2023-12-04 12-28-39](https://github.com/Pearson-Advance/frontend-app-sidebar-navigation/assets/62396424/8cd75480-34e5-4312-b4a3-8a9589ef3a26)

### Error message

#### Before

![Screenshot from 2023-12-04 12-27-35](https://github.com/Pearson-Advance/frontend-app-sidebar-navigation/assets/62396424/c748545a-47e5-4d53-b404-205a24febe49)

#### After

![Screenshot from 2023-12-04 12-28-54](https://github.com/Pearson-Advance/frontend-app-sidebar-navigation/assets/62396424/c6804947-3159-45df-b344-859e749a0eec)

## Reviewers:

- [ ] @AuraAlba 
- [ ] @anfbermudezme 
- [ ] @Jacatove 